### PR TITLE
Feat/card

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,12 @@ dependencies {
     compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.12.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.12.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.12.5'
+
+    //AWS
+    implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4'
+    implementation 'javax.xml.bind:jaxb-api:2.3.1'
+    implementation 'com.sun.xml.bind:jaxb-core:2.3.0.1'
+    implementation 'com.sun.xml.bind:jaxb-impl:2.3.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/sparta/trelloproject/common/exception/ResponseCode.java
+++ b/src/main/java/com/sparta/trelloproject/common/exception/ResponseCode.java
@@ -32,6 +32,7 @@ public enum ResponseCode {
 
     // 카드
     NOT_FOUND_CARD("해당 카드는 존재하지 않습니다."),
+    INVALID_UPLOAD("등록 오류입니다. 다시 시도해주세요."),
 
 
     // 댓글

--- a/src/main/java/com/sparta/trelloproject/common/exception/ResponseCode.java
+++ b/src/main/java/com/sparta/trelloproject/common/exception/ResponseCode.java
@@ -46,6 +46,10 @@ public enum ResponseCode {
     // 알림
 
 
+
+
+    // 매니저
+    MANAGER_ALREADY_EXISTS("이미 매니저가 존재합니다.")
     ;
 
     private final String message;

--- a/src/main/java/com/sparta/trelloproject/common/s3/S3Config.java
+++ b/src/main/java/com/sparta/trelloproject/common/s3/S3Config.java
@@ -10,6 +10,7 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class S3Config {
+
     @Value("${cloud.aws.credentials.accessKey}")
     private String accessKey;
     @Value("${cloud.aws.credentials.secretKey}")

--- a/src/main/java/com/sparta/trelloproject/common/s3/S3Config.java
+++ b/src/main/java/com/sparta/trelloproject/common/s3/S3Config.java
@@ -1,0 +1,28 @@
+package com.sparta.trelloproject.common.s3;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+            .withRegion(region)
+            .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+            .build();
+    }
+}

--- a/src/main/java/com/sparta/trelloproject/common/s3/S3Service.java
+++ b/src/main/java/com/sparta/trelloproject/common/s3/S3Service.java
@@ -4,7 +4,7 @@ import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
-import com.sparta.trelloproject.common.exception.NotFoundException;
+import com.sparta.trelloproject.common.exception.ForbiddenException;
 import com.sparta.trelloproject.common.exception.ResponseCode;
 import com.sparta.trelloproject.domain.card.dto.request.CardImageRequestDto;
 import com.sparta.trelloproject.domain.card.entity.Card;
@@ -15,6 +15,8 @@ import java.rmi.ServerException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.ErrorResponse;
 import org.springframework.web.multipart.MultipartFile;
 
 @RequiredArgsConstructor
@@ -28,10 +30,41 @@ public class S3Service {
     private String bucket;
 
     public String uploadFile(MultipartFile multipartFile, Card card) throws ServerException {
+        String url = uploadFileToS3(multipartFile);
+
+        CardImageRequestDto cardImageDto = createCardImageDto(multipartFile, url);
+
+        cardImageRepository.save(CardImage.of(cardImageDto, card));
+        return url;
+    }
+
+    @Transactional
+    public String updateFile(MultipartFile multipartFile, Card card, String existFilePath)
+        throws ServerException {
+        if (existFilePath != null && !existFilePath.isEmpty()) {
+            String existingFileName = existFilePath.substring(
+                existFilePath.lastIndexOf("/") + 1);
+            amazonS3Client.deleteObject(bucket, existingFileName);
+        }
+
+        String url = uploadFileToS3(multipartFile);
+
+        CardImageRequestDto cardImageDto = createCardImageDto(multipartFile, url);
+
+        CardImage cardImage = cardImageRepository.findByCardId(card.getId());
+
+        if (cardImage != null) {
+            cardImage.update(cardImageDto);
+        } else {
+            cardImageRepository.save(CardImage.of(cardImageDto, card));
+        }
+        return url;
+    }
+
+    private String uploadFileToS3(MultipartFile multipartFile) {
         try {
             String originalFileName = multipartFile.getOriginalFilename();
             String fileName = originalFileName.substring(0, originalFileName.lastIndexOf("."));
-            String extension = originalFileName.substring(originalFileName.lastIndexOf(".") + 1);
 
             ObjectMetadata metadata = new ObjectMetadata();
             metadata.setContentLength(multipartFile.getSize());
@@ -42,15 +75,17 @@ public class S3Service {
                     .withCannedAcl(CannedAccessControlList.PublicRead)
             );
             String url = amazonS3Client.getUrl(bucket, fileName).toString();
-
-            CardImageRequestDto cardImageDto = new CardImageRequestDto(url, fileName, extension);
-
-            cardImageRepository.save(CardImage.of(cardImageDto, card));
             return url;
-
         }
         catch (IOException e) {
-            throw new NotFoundException(ResponseCode.INVALID_UPLOAD);
+            throw new ForbiddenException(ResponseCode.INVALID_UPLOAD);
         }
+    }
+
+    private CardImageRequestDto createCardImageDto(MultipartFile multipartFile, String url) {
+        String originalFileName = multipartFile.getOriginalFilename();
+        String fileName = originalFileName.substring(0, originalFileName.lastIndexOf("."));
+        String extension = originalFileName.substring(originalFileName.lastIndexOf(".") + 1);
+        return new CardImageRequestDto(url, fileName, extension);
     }
 }

--- a/src/main/java/com/sparta/trelloproject/common/s3/S3Service.java
+++ b/src/main/java/com/sparta/trelloproject/common/s3/S3Service.java
@@ -21,6 +21,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 @RequiredArgsConstructor
 @Component
+@Transactional
 public class S3Service {
 
     private final AmazonS3Client amazonS3Client;
@@ -38,7 +39,6 @@ public class S3Service {
         return url;
     }
 
-    @Transactional
     public String updateFile(MultipartFile multipartFile, Card card, String existFilePath)
         throws ServerException {
         if (existFilePath != null && !existFilePath.isEmpty()) {

--- a/src/main/java/com/sparta/trelloproject/common/s3/S3Service.java
+++ b/src/main/java/com/sparta/trelloproject/common/s3/S3Service.java
@@ -17,7 +17,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.ErrorResponse;
 import org.springframework.web.multipart.MultipartFile;
 
 @RequiredArgsConstructor
@@ -77,7 +76,7 @@ public class S3Service {
                 new PutObjectRequest(bucket, fileName, multipartFile.getInputStream(), metadata)
                     .withCannedAcl(CannedAccessControlList.PublicRead)
             );
-            String url = amazonS3Client.getUrl(bucket, randomFileName+fileName).toString();
+            String url = amazonS3Client.getUrl(bucket, randomFileName + fileName).toString();
             return url;
         }
         catch (IOException e) {

--- a/src/main/java/com/sparta/trelloproject/common/s3/S3Service.java
+++ b/src/main/java/com/sparta/trelloproject/common/s3/S3Service.java
@@ -1,0 +1,56 @@
+package com.sparta.trelloproject.common.s3;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.sparta.trelloproject.common.exception.NotFoundException;
+import com.sparta.trelloproject.common.exception.ResponseCode;
+import com.sparta.trelloproject.domain.card.dto.request.CardImageRequestDto;
+import com.sparta.trelloproject.domain.card.entity.Card;
+import com.sparta.trelloproject.domain.card.entity.CardImage;
+import com.sparta.trelloproject.domain.card.repository.CardImageRepository;
+import java.io.IOException;
+import java.rmi.ServerException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+@RequiredArgsConstructor
+@Component
+public class S3Service {
+
+    private final AmazonS3Client amazonS3Client;
+    private final CardImageRepository cardImageRepository;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public String uploadFile(MultipartFile multipartFile, Card card) throws ServerException {
+        try {
+            String originalFileName = multipartFile.getOriginalFilename();
+            String fileName = originalFileName.substring(0, originalFileName.lastIndexOf("."));
+            String extension = originalFileName.substring(originalFileName.lastIndexOf(".") + 1);
+
+            ObjectMetadata metadata = new ObjectMetadata();
+            metadata.setContentLength(multipartFile.getSize());
+            metadata.setContentType(multipartFile.getContentType());
+
+            amazonS3Client.putObject(
+                new PutObjectRequest(bucket, fileName, multipartFile.getInputStream(), metadata)
+                    .withCannedAcl(CannedAccessControlList.PublicRead)
+            );
+            String url = amazonS3Client.getUrl(bucket, fileName).toString();
+
+            CardImageRequestDto cardImageDto = new CardImageRequestDto(url, fileName, extension);
+
+            cardImageRepository.save(CardImage.of(cardImageDto, card));
+            return url;
+
+        }
+        catch (IOException e) {
+            throw new NotFoundException(ResponseCode.INVALID_UPLOAD);
+        }
+    }
+}

--- a/src/main/java/com/sparta/trelloproject/common/s3/S3Service.java
+++ b/src/main/java/com/sparta/trelloproject/common/s3/S3Service.java
@@ -12,6 +12,7 @@ import com.sparta.trelloproject.domain.card.entity.CardImage;
 import com.sparta.trelloproject.domain.card.repository.CardImageRepository;
 import java.io.IOException;
 import java.rmi.ServerException;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -70,11 +71,13 @@ public class S3Service {
             metadata.setContentLength(multipartFile.getSize());
             metadata.setContentType(multipartFile.getContentType());
 
+            String randomFileName = UUID.randomUUID().toString();
+
             amazonS3Client.putObject(
                 new PutObjectRequest(bucket, fileName, multipartFile.getInputStream(), metadata)
                     .withCannedAcl(CannedAccessControlList.PublicRead)
             );
-            String url = amazonS3Client.getUrl(bucket, fileName).toString();
+            String url = amazonS3Client.getUrl(bucket, randomFileName+fileName).toString();
             return url;
         }
         catch (IOException e) {

--- a/src/main/java/com/sparta/trelloproject/domain/card/controller/CardController.java
+++ b/src/main/java/com/sparta/trelloproject/domain/card/controller/CardController.java
@@ -3,6 +3,7 @@ package com.sparta.trelloproject.domain.card.controller;
 import com.sparta.trelloproject.common.annotation.AuthUser;
 import com.sparta.trelloproject.common.response.SuccessResponse;
 import com.sparta.trelloproject.domain.card.dto.reponse.CardListResponseDto;
+import com.sparta.trelloproject.domain.card.dto.reponse.CardResponseDto;
 import com.sparta.trelloproject.domain.card.dto.request.CardRequestDto;
 import com.sparta.trelloproject.domain.card.service.CardService;
 import java.time.LocalDateTime;
@@ -84,5 +85,15 @@ public class CardController {
         @RequestParam(defaultValue = "10") int size) {
         return ResponseEntity.ok(
             cardService.getCardList(title, contents, manager, dueDateFrom, dueDateTo, page, size));
+    }
+
+    /**
+     * 카드를 상세 조회합니다.
+     * @param id card의 id를 검색합니다.
+     * @return
+     */
+    @GetMapping("/cards/{id}")
+    public ResponseEntity<CardResponseDto> getCard(@PathVariable Long id) {
+        return ResponseEntity.ok(cardService.getCard(id));
     }
 }

--- a/src/main/java/com/sparta/trelloproject/domain/card/controller/CardController.java
+++ b/src/main/java/com/sparta/trelloproject/domain/card/controller/CardController.java
@@ -90,7 +90,7 @@ public class CardController {
     /**
      * 카드를 상세 조회합니다.
      * @param id card의 id를 검색합니다.
-     * @return
+     * @return 카드의 내용과, 카드의 댓글, 카드의 이미지를 반환합니다.
      */
     @GetMapping("/cards/{id}")
     public ResponseEntity<CardResponseDto> getCard(@PathVariable Long id) {

--- a/src/main/java/com/sparta/trelloproject/domain/card/controller/CardController.java
+++ b/src/main/java/com/sparta/trelloproject/domain/card/controller/CardController.java
@@ -50,6 +50,7 @@ public class CardController {
 
     /**
      * 카드를 수정합니다
+     *
      * @param file           파일을 입력받습니다
      * @param cardRequestDto 카드를 등록할 타이틀, 컨텐츠, 마감일과 등록할 list의 id, 워크스페이스 접근 권한을 알기위한 workSpaceid를
      *                       받습니다
@@ -94,6 +95,7 @@ public class CardController {
 
     /**
      * 카드를 상세 조회합니다.
+     *
      * @param id card의 id를 검색합니다.
      * @return 카드의 내용과, 카드의 댓글, 카드의 이미지를 반환합니다.
      */
@@ -104,6 +106,7 @@ public class CardController {
 
     /**
      * 카드를 삭제합니다
+     *
      * @param id 카드 id를 입력받습니다
      * @return
      */

--- a/src/main/java/com/sparta/trelloproject/domain/card/controller/CardController.java
+++ b/src/main/java/com/sparta/trelloproject/domain/card/controller/CardController.java
@@ -102,4 +102,14 @@ public class CardController {
         return ResponseEntity.ok(SuccessResponse.of(cardService.getCard(id)));
     }
 
+    /**
+     * 카드를 삭제합니다
+     * @param id 카드 id를 입력받습니다
+     * @return
+     */
+    @DeleteMapping("/cards/{id}")
+    public ResponseEntity<SuccessResponse<String>> deleteCard(@PathVariable Long id) {
+        cardService.deleteCard(id);
+        return ResponseEntity.ok(SuccessResponse.of(null));
+    }
 }

--- a/src/main/java/com/sparta/trelloproject/domain/card/controller/CardController.java
+++ b/src/main/java/com/sparta/trelloproject/domain/card/controller/CardController.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -30,6 +31,7 @@ public class CardController {
 
     /**
      * 카드를 생성합니다
+     *
      * @param file           파일을 입력받습니다
      * @param cardRequestDto 카드를 등록할 타이틀, 컨텐츠, 마감일과 등록할 list의 id, 워크스페이스 접근 권한을 알기위한 workSpaceid를
      *                       받습니다
@@ -48,34 +50,37 @@ public class CardController {
 
     /**
      * 카드를 수정합니다
-     * @param file 파일을 입력받습니다
+     * @param file           파일을 입력받습니다
      * @param cardRequestDto 카드를 등록할 타이틀, 컨텐츠, 마감일과 등록할 list의 id, 워크스페이스 접근 권한을 알기위한 workSpaceid를
      *                       받습니다
-     * @param cardId 수정할 카드 id를 PathVariable 입력받습니다.
-     * @param authUser 현재 로그인중인 유저 정보를 가져오기 위함입니다.
+     * @param cardId         수정할 카드 id를 PathVariable 입력받습니다.
+     * @param authUser       현재 로그인중인 유저 정보를 가져오기 위함입니다.
      * @return 수정된 파일 이름을 반환합니다.
      */
     @PatchMapping("/cards/{cardId}")
-    public ResponseEntity<SuccessResponse<String>> updateCard(@RequestParam("file") MultipartFile file,
+    public ResponseEntity<SuccessResponse<String>> updateCard(
+        @RequestParam("file") MultipartFile file,
         @ModelAttribute CardRequestDto cardRequestDto, @PathVariable Long cardId,
         @AuthenticationPrincipal AuthUser authUser) {
-        String uploadedFileName = cardService.updateCard(file, cardRequestDto, cardId, authUser.getUserId());
+        String uploadedFileName = cardService.updateCard(file, cardRequestDto, cardId,
+            authUser.getUserId());
         return ResponseEntity.ok(SuccessResponse.of(uploadedFileName));
     }
 
     /**
      * 카드를 다건 조회합니다, 제목, 내용, 매니저이름, 기한을 검색하며 페이지네이션을 구현했습니다.
-     * @param title 제목
-     * @param contents 내용
-     * @param manager 매니저 이름
+     *
+     * @param title       제목
+     * @param contents    내용
+     * @param manager     매니저 이름
      * @param dueDateFrom 기한시작
-     * @param dueDateTo 기한 끝
-     * @param page 페이지
-     * @param size 페이지
+     * @param dueDateTo   기한 끝
+     * @param page        페이지
+     * @param size        페이지
      * @return
      */
     @GetMapping("/cards")
-    public ResponseEntity<Page<CardListResponseDto>> getCardList(
+    public ResponseEntity<SuccessResponse<Page<CardListResponseDto>>> getCardList(
         @RequestParam(required = false) String title,
         @RequestParam(required = false) String contents,
         @RequestParam(required = false) String manager,
@@ -83,8 +88,8 @@ public class CardController {
         @RequestParam(name = "due-date-to", required = false) LocalDateTime dueDateTo,
         @RequestParam(defaultValue = "1") int page,
         @RequestParam(defaultValue = "10") int size) {
-        return ResponseEntity.ok(
-            cardService.getCardList(title, contents, manager, dueDateFrom, dueDateTo, page, size));
+        return ResponseEntity.ok(SuccessResponse.of(
+            cardService.getCardList(title, contents, manager, dueDateFrom, dueDateTo, page, size)));
     }
 
     /**
@@ -93,7 +98,8 @@ public class CardController {
      * @return 카드의 내용과, 카드의 댓글, 카드의 이미지를 반환합니다.
      */
     @GetMapping("/cards/{id}")
-    public ResponseEntity<CardResponseDto> getCard(@PathVariable Long id) {
-        return ResponseEntity.ok(cardService.getCard(id));
+    public ResponseEntity<SuccessResponse<CardResponseDto>> getCard(@PathVariable Long id) {
+        return ResponseEntity.ok(SuccessResponse.of(cardService.getCard(id)));
     }
+
 }

--- a/src/main/java/com/sparta/trelloproject/domain/card/controller/CardController.java
+++ b/src/main/java/com/sparta/trelloproject/domain/card/controller/CardController.java
@@ -1,4 +1,32 @@
 package com.sparta.trelloproject.domain.card.controller;
 
+import com.sparta.trelloproject.common.annotation.AuthUser;
+import com.sparta.trelloproject.common.response.SuccessResponse;
+import com.sparta.trelloproject.domain.card.dto.request.CardRequestDto;
+import com.sparta.trelloproject.domain.card.service.CardService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
 public class CardController {
+
+    private final CardService cardService;
+
+    @PostMapping("/cards")
+    public ResponseEntity<SuccessResponse<String>> saveCard(@RequestParam("file") MultipartFile file,
+        @ModelAttribute CardRequestDto cardRequestDto,
+        @AuthenticationPrincipal AuthUser authUser) {
+        String uploadedFileName = cardService.saveCard(authUser.getUserId(),file, cardRequestDto);
+
+        return ResponseEntity.ok(SuccessResponse.of(uploadedFileName));
+    }
 }

--- a/src/main/java/com/sparta/trelloproject/domain/card/controller/CardController.java
+++ b/src/main/java/com/sparta/trelloproject/domain/card/controller/CardController.java
@@ -8,6 +8,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -21,12 +23,38 @@ public class CardController {
 
     private final CardService cardService;
 
+    /**
+     * 카드를 생성합니다
+     * @param file           파일을 입력받습니다
+     * @param cardRequestDto 카드를 등록할 타이틀, 컨텐츠, 마감일과 등록할 list의 id, 워크스페이스 접근 권한을 알기위한 workSpaceid를
+     *                       받습니다
+     * @param authUser       현재 로그인중인 유저 정보를 가져오기 위함입니다.
+     * @return 업로드한 파일 이름이 반환됩니다.
+     */
     @PostMapping("/cards")
-    public ResponseEntity<SuccessResponse<String>> saveCard(@RequestParam("file") MultipartFile file,
+    public ResponseEntity<SuccessResponse<String>> saveCard(
+        @RequestParam("file") MultipartFile file,
         @ModelAttribute CardRequestDto cardRequestDto,
         @AuthenticationPrincipal AuthUser authUser) {
-        String uploadedFileName = cardService.saveCard(authUser.getUserId(),file, cardRequestDto);
+        String uploadedFileName = cardService.saveCard(authUser.getUserId(), file, cardRequestDto);
 
+        return ResponseEntity.ok(SuccessResponse.of(uploadedFileName));
+    }
+
+    /**
+     * 카드를 수정합니다
+     * @param file 파일을 입력받습니다
+     * @param cardRequestDto 카드를 등록할 타이틀, 컨텐츠, 마감일과 등록할 list의 id, 워크스페이스 접근 권한을 알기위한 workSpaceid를
+     *                       받습니다
+     * @param cardId 수정할 카드 id를 PathVariable 입력받습니다.
+     * @param authUser 현재 로그인중인 유저 정보를 가져오기 위함입니다.
+     * @return 수정된 파일 이름을 반환합니다.
+     */
+    @PatchMapping("/cards/{cardId}")
+    public ResponseEntity<SuccessResponse<String>> updateCard(@RequestParam("file") MultipartFile file,
+        @ModelAttribute CardRequestDto cardRequestDto, @PathVariable Long cardId,
+        @AuthenticationPrincipal AuthUser authUser) {
+        String uploadedFileName = cardService.updateCard(file, cardRequestDto, cardId, authUser.getUserId());
         return ResponseEntity.ok(SuccessResponse.of(uploadedFileName));
     }
 }

--- a/src/main/java/com/sparta/trelloproject/domain/card/controller/CardController.java
+++ b/src/main/java/com/sparta/trelloproject/domain/card/controller/CardController.java
@@ -2,11 +2,15 @@ package com.sparta.trelloproject.domain.card.controller;
 
 import com.sparta.trelloproject.common.annotation.AuthUser;
 import com.sparta.trelloproject.common.response.SuccessResponse;
+import com.sparta.trelloproject.domain.card.dto.reponse.CardListResponseDto;
 import com.sparta.trelloproject.domain.card.dto.request.CardRequestDto;
 import com.sparta.trelloproject.domain.card.service.CardService;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -56,5 +60,29 @@ public class CardController {
         @AuthenticationPrincipal AuthUser authUser) {
         String uploadedFileName = cardService.updateCard(file, cardRequestDto, cardId, authUser.getUserId());
         return ResponseEntity.ok(SuccessResponse.of(uploadedFileName));
+    }
+
+    /**
+     * 카드를 다건 조회합니다, 제목, 내용, 매니저이름, 기한을 검색하며 페이지네이션을 구현했습니다.
+     * @param title 제목
+     * @param contents 내용
+     * @param manager 매니저 이름
+     * @param dueDateFrom 기한시작
+     * @param dueDateTo 기한 끝
+     * @param page 페이지
+     * @param size 페이지
+     * @return
+     */
+    @GetMapping("/cards")
+    public ResponseEntity<Page<CardListResponseDto>> getCardList(
+        @RequestParam(required = false) String title,
+        @RequestParam(required = false) String contents,
+        @RequestParam(required = false) String manager,
+        @RequestParam(name = "due-date-from", required = false) LocalDateTime dueDateFrom,
+        @RequestParam(name = "due-date-to", required = false) LocalDateTime dueDateTo,
+        @RequestParam(defaultValue = "1") int page,
+        @RequestParam(defaultValue = "10") int size) {
+        return ResponseEntity.ok(
+            cardService.getCardList(title, contents, manager, dueDateFrom, dueDateTo, page, size));
     }
 }

--- a/src/main/java/com/sparta/trelloproject/domain/card/controller/ManagerController.java
+++ b/src/main/java/com/sparta/trelloproject/domain/card/controller/ManagerController.java
@@ -1,0 +1,25 @@
+package com.sparta.trelloproject.domain.card.controller;
+
+import com.sparta.trelloproject.common.response.SuccessResponse;
+import com.sparta.trelloproject.domain.card.dto.request.ManagerRequestDto;
+import com.sparta.trelloproject.domain.card.service.ManagerService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1")
+public class ManagerController {
+
+    private final ManagerService managerService;
+
+    @PostMapping("/manager")
+    public ResponseEntity<SuccessResponse<String>> saveCard(@RequestBody ManagerRequestDto managerRequestDto){
+        managerService.addManager(managerRequestDto);
+        return ResponseEntity.ok(SuccessResponse.of(null));
+    }
+}

--- a/src/main/java/com/sparta/trelloproject/domain/card/controller/ManagerController.java
+++ b/src/main/java/com/sparta/trelloproject/domain/card/controller/ManagerController.java
@@ -19,11 +19,13 @@ public class ManagerController {
 
     /**
      * 매니저를 등록합니다
+     *
      * @param managerRequestDto userid와 cardid를 받습니다
      * @return
      */
     @PostMapping("/manager")
-    public ResponseEntity<SuccessResponse<String>> saveCard(@RequestBody ManagerRequestDto managerRequestDto){
+    public ResponseEntity<SuccessResponse<String>> saveCard(
+        @RequestBody ManagerRequestDto managerRequestDto) {
         managerService.addManager(managerRequestDto);
         return ResponseEntity.ok(SuccessResponse.of(null));
     }

--- a/src/main/java/com/sparta/trelloproject/domain/card/controller/ManagerController.java
+++ b/src/main/java/com/sparta/trelloproject/domain/card/controller/ManagerController.java
@@ -17,6 +17,11 @@ public class ManagerController {
 
     private final ManagerService managerService;
 
+    /**
+     * 매니저를 등록합니다
+     * @param managerRequestDto userid와 cardid를 받습니다
+     * @return
+     */
     @PostMapping("/manager")
     public ResponseEntity<SuccessResponse<String>> saveCard(@RequestBody ManagerRequestDto managerRequestDto){
         managerService.addManager(managerRequestDto);

--- a/src/main/java/com/sparta/trelloproject/domain/card/dto/reponse/CardImageResponseDto.java
+++ b/src/main/java/com/sparta/trelloproject/domain/card/dto/reponse/CardImageResponseDto.java
@@ -5,9 +5,10 @@ import lombok.Getter;
 
 @Getter
 public class CardImageResponseDto {
+
     private String path;
 
-    public CardImageResponseDto(String path) {
+    private CardImageResponseDto(String path) {
         this.path = path;
     }
 

--- a/src/main/java/com/sparta/trelloproject/domain/card/dto/reponse/CardImageResponseDto.java
+++ b/src/main/java/com/sparta/trelloproject/domain/card/dto/reponse/CardImageResponseDto.java
@@ -1,0 +1,17 @@
+package com.sparta.trelloproject.domain.card.dto.reponse;
+
+import com.sparta.trelloproject.domain.card.entity.CardImage;
+import lombok.Getter;
+
+@Getter
+public class CardImageResponseDto {
+    private String path;
+
+    public CardImageResponseDto(String path) {
+        this.path = path;
+    }
+
+    public static CardImageResponseDto from(CardImage cardImage) {
+        return new CardImageResponseDto(cardImage.getPath());
+    }
+}

--- a/src/main/java/com/sparta/trelloproject/domain/card/dto/reponse/CardListResponseDto.java
+++ b/src/main/java/com/sparta/trelloproject/domain/card/dto/reponse/CardListResponseDto.java
@@ -1,5 +1,6 @@
 package com.sparta.trelloproject.domain.card.dto.reponse;
 
+import com.sparta.trelloproject.domain.card.entity.Card;
 import java.time.LocalDateTime;
 import lombok.Getter;
 
@@ -18,8 +19,9 @@ public class CardListResponseDto {
         this.dueDate = dueDate;
     }
 
-    public static CardListResponseDto of(Long id, String title, String contents, LocalDateTime dueDate) {
-        return new CardListResponseDto(id, title, contents, dueDate);
+    public static CardListResponseDto of(Card card) {
+        return new CardListResponseDto(card.getId(), card.getTitle(), card.getContents(),
+            card.getDueDate());
     }
 }
 

--- a/src/main/java/com/sparta/trelloproject/domain/card/dto/reponse/CardListResponseDto.java
+++ b/src/main/java/com/sparta/trelloproject/domain/card/dto/reponse/CardListResponseDto.java
@@ -1,0 +1,25 @@
+package com.sparta.trelloproject.domain.card.dto.reponse;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+public class CardListResponseDto {
+
+    private final Long id;
+    private final String title;
+    private final String contents;
+    private final LocalDateTime dueDate;
+
+    public CardListResponseDto(Long id, String title, String contents, LocalDateTime dueDate) {
+        this.id = id;
+        this.title = title;
+        this.contents = contents;
+        this.dueDate = dueDate;
+    }
+
+    public static CardListResponseDto of(Long id, String title, String contents, LocalDateTime dueDate) {
+        return new CardListResponseDto(id, title, contents, dueDate);
+    }
+}
+

--- a/src/main/java/com/sparta/trelloproject/domain/card/dto/reponse/CardResponseDto.java
+++ b/src/main/java/com/sparta/trelloproject/domain/card/dto/reponse/CardResponseDto.java
@@ -1,0 +1,39 @@
+package com.sparta.trelloproject.domain.card.dto.reponse;
+
+import com.sparta.trelloproject.domain.card.entity.Card;
+import com.sparta.trelloproject.domain.comment.dto.response.UpdateCommentResponse;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class CardResponseDto {
+
+    private final Long id;
+    private final String title;
+    private final String contents;
+    private final LocalDateTime dueDate;
+    private final List<UpdateCommentResponse> comments;
+    private CardImageResponseDto cardImage;
+
+    private CardResponseDto(Long id, String title, String contents, LocalDateTime dueDate,
+        List<UpdateCommentResponse> comments, CardImageResponseDto cardImage) {
+        this.id = id;
+        this.title = title;
+        this.contents = contents;
+        this.dueDate = dueDate;
+        this.comments = comments;
+        this.cardImage = cardImage;
+    }
+
+    public static CardResponseDto of(Card card, List<UpdateCommentResponse> comments, CardImageResponseDto cardImage) {
+        return new CardResponseDto(
+            card.getId(),
+            card.getTitle(),
+            card.getContents(),
+            card.getDueDate(),
+            comments,
+            cardImage
+        );
+    }
+}

--- a/src/main/java/com/sparta/trelloproject/domain/card/dto/reponse/CardResponseDto.java
+++ b/src/main/java/com/sparta/trelloproject/domain/card/dto/reponse/CardResponseDto.java
@@ -26,7 +26,8 @@ public class CardResponseDto {
         this.cardImage = cardImage;
     }
 
-    public static CardResponseDto of(Card card, List<UpdateCommentResponse> comments, CardImageResponseDto cardImage) {
+    public static CardResponseDto of(Card card, List<UpdateCommentResponse> comments,
+        CardImageResponseDto cardImage) {
         return new CardResponseDto(
             card.getId(),
             card.getTitle(),

--- a/src/main/java/com/sparta/trelloproject/domain/card/dto/request/CardImageRequestDto.java
+++ b/src/main/java/com/sparta/trelloproject/domain/card/dto/request/CardImageRequestDto.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class CardImageRequestDto {
+
     private String path;
     private String fileName;
     private String originName;

--- a/src/main/java/com/sparta/trelloproject/domain/card/dto/request/CardImageRequestDto.java
+++ b/src/main/java/com/sparta/trelloproject/domain/card/dto/request/CardImageRequestDto.java
@@ -1,0 +1,14 @@
+package com.sparta.trelloproject.domain.card.dto.request;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CardImageRequestDto {
+    private String path;
+    private String fileName;
+    private String originName;
+}
+

--- a/src/main/java/com/sparta/trelloproject/domain/card/dto/request/CardRequestDto.java
+++ b/src/main/java/com/sparta/trelloproject/domain/card/dto/request/CardRequestDto.java
@@ -1,0 +1,20 @@
+package com.sparta.trelloproject.domain.card.dto.request;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CardRequestDto {
+    private Long listId;
+    private String title;
+    private String contents;
+    private LocalDateTime dueDate;
+    private Long workSpaceId;
+}
+

--- a/src/main/java/com/sparta/trelloproject/domain/card/dto/request/CardRequestDto.java
+++ b/src/main/java/com/sparta/trelloproject/domain/card/dto/request/CardRequestDto.java
@@ -11,6 +11,7 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 public class CardRequestDto {
+
     private Long listId;
     private String title;
     private String contents;

--- a/src/main/java/com/sparta/trelloproject/domain/card/dto/request/ManagerRequestDto.java
+++ b/src/main/java/com/sparta/trelloproject/domain/card/dto/request/ManagerRequestDto.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 
 @Getter
 public class ManagerRequestDto {
+
     private Long userId;
     private Long cardId;
 }

--- a/src/main/java/com/sparta/trelloproject/domain/card/dto/request/ManagerRequestDto.java
+++ b/src/main/java/com/sparta/trelloproject/domain/card/dto/request/ManagerRequestDto.java
@@ -1,0 +1,9 @@
+package com.sparta.trelloproject.domain.card.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class ManagerRequestDto {
+    private Long userId;
+    private Long cardId;
+}

--- a/src/main/java/com/sparta/trelloproject/domain/card/entity/Card.java
+++ b/src/main/java/com/sparta/trelloproject/domain/card/entity/Card.java
@@ -1,27 +1,25 @@
 package com.sparta.trelloproject.domain.card.entity;
 
 import com.sparta.trelloproject.common.entity.Timestamped;
-import com.sparta.trelloproject.domain.card.dto.request.CardRequestDto;
 import com.sparta.trelloproject.domain.list.entity.Lists;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 import java.time.LocalDateTime;
-import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "cards")
 @Getter
-@NoArgsConstructor
 public class Card extends Timestamped {
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @NotNull
     private String title;
+
     private String contents;
     private LocalDateTime dueDate;
 
@@ -29,20 +27,4 @@ public class Card extends Timestamped {
     @JoinColumn(name = "lists_id")
     private Lists list;
 
-    private Card(String title, String contents, LocalDateTime dueDate, Lists list) {
-        this.title = title;
-        this.contents = contents;
-        this.dueDate = dueDate;
-        this.list = list;
-    }
-
-    public static Card from(CardRequestDto cardRequestDto, Lists list) {
-        return new Card(cardRequestDto.getTitle(), cardRequestDto.getContents(), cardRequestDto.getDueDate(), list);
-    }
-
-    public void update(CardRequestDto cardRequestDto) {
-        this.title = cardRequestDto.getTitle();
-        this.contents = cardRequestDto.getContents();
-        this.dueDate = cardRequestDto.getDueDate();
-    }
 }

--- a/src/main/java/com/sparta/trelloproject/domain/card/entity/Card.java
+++ b/src/main/java/com/sparta/trelloproject/domain/card/entity/Card.java
@@ -37,7 +37,8 @@ public class Card extends Timestamped {
     }
 
     public static Card from(CardRequestDto cardRequestDto, Lists list) {
-        return new Card(cardRequestDto.getTitle(), cardRequestDto.getContents(), cardRequestDto.getDueDate(), list);
+        return new Card(cardRequestDto.getTitle(), cardRequestDto.getContents(),
+            cardRequestDto.getDueDate(), list);
     }
 
     public void update(CardRequestDto cardRequestDto) {

--- a/src/main/java/com/sparta/trelloproject/domain/card/entity/Card.java
+++ b/src/main/java/com/sparta/trelloproject/domain/card/entity/Card.java
@@ -1,25 +1,27 @@
 package com.sparta.trelloproject.domain.card.entity;
 
 import com.sparta.trelloproject.common.entity.Timestamped;
+import com.sparta.trelloproject.domain.card.dto.request.CardRequestDto;
 import com.sparta.trelloproject.domain.list.entity.Lists;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 import java.time.LocalDateTime;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "cards")
 @Getter
+@NoArgsConstructor
 public class Card extends Timestamped {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @NotNull
     private String title;
-
     private String contents;
     private LocalDateTime dueDate;
 
@@ -27,4 +29,20 @@ public class Card extends Timestamped {
     @JoinColumn(name = "lists_id")
     private Lists list;
 
+    private Card(String title, String contents, LocalDateTime dueDate, Lists list) {
+        this.title = title;
+        this.contents = contents;
+        this.dueDate = dueDate;
+        this.list = list;
+    }
+
+    public static Card from(CardRequestDto cardRequestDto, Lists list) {
+        return new Card(cardRequestDto.getTitle(), cardRequestDto.getContents(), cardRequestDto.getDueDate(), list);
+    }
+
+    public void update(CardRequestDto cardRequestDto) {
+        this.title = cardRequestDto.getTitle();
+        this.contents = cardRequestDto.getContents();
+        this.dueDate = cardRequestDto.getDueDate();
+    }
 }

--- a/src/main/java/com/sparta/trelloproject/domain/card/entity/Card.java
+++ b/src/main/java/com/sparta/trelloproject/domain/card/entity/Card.java
@@ -1,6 +1,7 @@
 package com.sparta.trelloproject.domain.card.entity;
 
 import com.sparta.trelloproject.common.entity.Timestamped;
+import com.sparta.trelloproject.domain.card.dto.request.CardRequestDto;
 import com.sparta.trelloproject.domain.list.entity.Lists;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
@@ -19,11 +20,22 @@ public class Card extends Timestamped {
 
     @NotNull
     private String title;
-
     private String contents;
     private LocalDateTime dueDate;
 
     @ManyToOne
     @JoinColumn(name = "lists_id")
     private Lists list;
+
+    private Card(String title, String contents, LocalDateTime dueDate,Lists list)
+    {
+        this.title = title;
+        this.contents = contents;
+        this.dueDate = dueDate;
+        this.list = list;
+    }
+
+    public static Card from(CardRequestDto cardRequestDto, Lists list) {
+        return new Card(cardRequestDto.getTitle(), cardRequestDto.getContents(), cardRequestDto.getDueDate(), list);
+    }
 }

--- a/src/main/java/com/sparta/trelloproject/domain/card/entity/Card.java
+++ b/src/main/java/com/sparta/trelloproject/domain/card/entity/Card.java
@@ -3,11 +3,16 @@ package com.sparta.trelloproject.domain.card.entity;
 import com.sparta.trelloproject.common.entity.Timestamped;
 import com.sparta.trelloproject.domain.card.dto.request.CardRequestDto;
 import com.sparta.trelloproject.domain.list.entity.Lists;
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
-import lombok.Getter;
-
 import java.time.LocalDateTime;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity

--- a/src/main/java/com/sparta/trelloproject/domain/card/entity/Card.java
+++ b/src/main/java/com/sparta/trelloproject/domain/card/entity/Card.java
@@ -8,10 +8,12 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "cards")
 @Getter
+@NoArgsConstructor
 public class Card extends Timestamped {
 
     @Id
@@ -27,8 +29,7 @@ public class Card extends Timestamped {
     @JoinColumn(name = "lists_id")
     private Lists list;
 
-    private Card(String title, String contents, LocalDateTime dueDate,Lists list)
-    {
+    private Card(String title, String contents, LocalDateTime dueDate, Lists list) {
         this.title = title;
         this.contents = contents;
         this.dueDate = dueDate;
@@ -37,5 +38,11 @@ public class Card extends Timestamped {
 
     public static Card from(CardRequestDto cardRequestDto, Lists list) {
         return new Card(cardRequestDto.getTitle(), cardRequestDto.getContents(), cardRequestDto.getDueDate(), list);
+    }
+
+    public void update(CardRequestDto cardRequestDto) {
+        this.title = cardRequestDto.getTitle();
+        this.contents = cardRequestDto.getContents();
+        this.dueDate = cardRequestDto.getDueDate();
     }
 }

--- a/src/main/java/com/sparta/trelloproject/domain/card/entity/CardImage.java
+++ b/src/main/java/com/sparta/trelloproject/domain/card/entity/CardImage.java
@@ -1,5 +1,6 @@
 package com.sparta.trelloproject.domain.card.entity;
 
+import com.sparta.trelloproject.domain.card.dto.request.CardImageRequestDto;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
@@ -25,4 +26,15 @@ public class CardImage {
     @ManyToOne
     @JoinColumn(name = "card_id")
     private Card card;
+
+    private CardImage(String path, String fileName, String originName, Card card){
+        this.path = path;
+        this.fileName = fileName;
+        this.originName = originName;
+        this.card = card;
+    }
+
+    public static CardImage of(CardImageRequestDto cardImageDto, Card card) {
+        return new CardImage(cardImageDto.getPath(), cardImageDto.getFileName(), cardImageDto.getOriginName(), card);
+    }
 }

--- a/src/main/java/com/sparta/trelloproject/domain/card/entity/CardImage.java
+++ b/src/main/java/com/sparta/trelloproject/domain/card/entity/CardImage.java
@@ -4,10 +4,12 @@ import com.sparta.trelloproject.domain.card.dto.request.CardImageRequestDto;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "card_image")
 @Getter
+@NoArgsConstructor
 public class CardImage {
 
     @Id
@@ -36,5 +38,11 @@ public class CardImage {
 
     public static CardImage of(CardImageRequestDto cardImageDto, Card card) {
         return new CardImage(cardImageDto.getPath(), cardImageDto.getFileName(), cardImageDto.getOriginName(), card);
+    }
+
+    public void update(CardImageRequestDto cardImageDto) {
+        this.path = cardImageDto.getPath();
+        this.fileName = cardImageDto.getFileName();
+        this.originName = cardImageDto.getOriginName();
     }
 }

--- a/src/main/java/com/sparta/trelloproject/domain/card/entity/CardImage.java
+++ b/src/main/java/com/sparta/trelloproject/domain/card/entity/CardImage.java
@@ -1,7 +1,13 @@
 package com.sparta.trelloproject.domain.card.entity;
 
 import com.sparta.trelloproject.domain.card.dto.request.CardImageRequestDto;
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -29,7 +35,7 @@ public class CardImage {
     @JoinColumn(name = "card_id")
     private Card card;
 
-    private CardImage(String path, String fileName, String originName, Card card){
+    private CardImage(String path, String fileName, String originName, Card card) {
         this.path = path;
         this.fileName = fileName;
         this.originName = originName;
@@ -37,7 +43,8 @@ public class CardImage {
     }
 
     public static CardImage of(CardImageRequestDto cardImageDto, Card card) {
-        return new CardImage(cardImageDto.getPath(), cardImageDto.getFileName(), cardImageDto.getOriginName(), card);
+        return new CardImage(cardImageDto.getPath(), cardImageDto.getFileName(),
+            cardImageDto.getOriginName(), card);
     }
 
     public void update(CardImageRequestDto cardImageDto) {

--- a/src/main/java/com/sparta/trelloproject/domain/card/entity/Manager.java
+++ b/src/main/java/com/sparta/trelloproject/domain/card/entity/Manager.java
@@ -1,7 +1,13 @@
 package com.sparta.trelloproject.domain.card.entity;
 
 import com.sparta.trelloproject.domain.user.entity.User;
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 

--- a/src/main/java/com/sparta/trelloproject/domain/card/entity/Manager.java
+++ b/src/main/java/com/sparta/trelloproject/domain/card/entity/Manager.java
@@ -23,4 +23,13 @@ public class Manager {
     @ManyToOne
     @JoinColumn(name = "cards_id")
     private Card card;
+
+    private Manager(User user, Card card) {
+        this.user = user;
+        this.card = card;
+    }
+
+    public static Manager from(User user, Card card) {
+        return new Manager(user, card);
+    }
 }

--- a/src/main/java/com/sparta/trelloproject/domain/card/repository/CardImageRepository.java
+++ b/src/main/java/com/sparta/trelloproject/domain/card/repository/CardImageRepository.java
@@ -7,5 +7,4 @@ public interface CardImageRepository extends JpaRepository<CardImage, Long> {
 
     CardImage findByCardId(Long cardId);
 
-    void deleteByCardId(Long id);
 }

--- a/src/main/java/com/sparta/trelloproject/domain/card/repository/CardImageRepository.java
+++ b/src/main/java/com/sparta/trelloproject/domain/card/repository/CardImageRepository.java
@@ -1,0 +1,11 @@
+package com.sparta.trelloproject.domain.card.repository;
+
+import com.sparta.trelloproject.domain.card.entity.CardImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CardImageRepository extends JpaRepository<CardImage, Long> {
+
+    CardImage findByCardId(Long cardId);
+
+    void deleteByCardId(Long id);
+}

--- a/src/main/java/com/sparta/trelloproject/domain/card/repository/CardQueryRepository.java
+++ b/src/main/java/com/sparta/trelloproject/domain/card/repository/CardQueryRepository.java
@@ -1,4 +1,12 @@
 package com.sparta.trelloproject.domain.card.repository;
 
+import com.sparta.trelloproject.domain.card.dto.reponse.CardListResponseDto;
+import java.time.LocalDateTime;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 public interface CardQueryRepository {
+
+    Page<CardListResponseDto> findCardList(String title, String contents, String manager,
+        LocalDateTime dueDateFrom, LocalDateTime dueDateTo, Pageable pageable);
 }

--- a/src/main/java/com/sparta/trelloproject/domain/card/repository/CardQueryRepositoryImpl.java
+++ b/src/main/java/com/sparta/trelloproject/domain/card/repository/CardQueryRepositoryImpl.java
@@ -1,4 +1,91 @@
 package com.sparta.trelloproject.domain.card.repository;
 
+import static com.sparta.trelloproject.domain.card.entity.QCard.card;
+import static com.sparta.trelloproject.domain.card.entity.QManager.manager;
+import static com.sparta.trelloproject.domain.user.entity.QUser.user;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Wildcard;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sparta.trelloproject.domain.card.dto.reponse.CardListResponseDto;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
 public class CardQueryRepositoryImpl implements CardQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<CardListResponseDto> findCardList(String title, String contents, String managerName,
+        LocalDateTime dueDateFrom, LocalDateTime dueDateTo, Pageable pageable) {
+        List<CardListResponseDto> results = queryFactory
+            .select(
+                Projections.constructor(
+                    CardListResponseDto.class,
+                    card.id,
+                    card.title,
+                    card.contents,
+                    card.dueDate
+                )
+            )
+            .from(card)
+            .leftJoin(manager).on(manager.card.eq(card))
+            .leftJoin(manager.user, user)
+            .where(
+                titleContains(title),
+                contentsContains(contents),
+                managerNicknameContains(managerName),
+                dueDateBetween(dueDateFrom, dueDateTo)
+            )
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .orderBy(card.id.desc())
+            .fetch();
+
+        Long totalCount = queryFactory
+            .select(Wildcard.count)
+            .from(card)
+            .leftJoin(manager).on(manager.card.eq(card))
+            .leftJoin(manager.user, user)
+            .where(
+                titleContains(title),
+                contentsContains(contents),
+                managerNicknameContains(managerName),
+                dueDateBetween(dueDateFrom, dueDateTo)
+            ).fetchOne();
+
+        return new PageImpl<>(results, pageable, totalCount);
+    }
+
+    private BooleanExpression titleContains(String title) {
+        return title != null ? card.title.containsIgnoreCase(title) : null;
+    }
+
+    private BooleanExpression contentsContains(String contents) {
+        return contents != null ? card.contents.containsIgnoreCase(contents) : null;
+    }
+
+    private BooleanExpression managerNicknameContains(String managerName) {
+        return managerName != null ? user.name.containsIgnoreCase(managerName) : null;
+    }
+
+    private BooleanExpression dueDateBetween(LocalDateTime dueDateFrom, LocalDateTime dueDateTo) {
+        if (dueDateFrom != null && dueDateTo != null) {
+            return card.dueDate.between(dueDateFrom, dueDateTo);
+        } else if (dueDateFrom != null) {
+            return card.dueDate.after(dueDateFrom);
+        } else if (dueDateTo != null) {
+            return card.dueDate.before(dueDateTo);
+        } else {
+            return null;
+        }
+    }
 }

--- a/src/main/java/com/sparta/trelloproject/domain/card/repository/CardRepository.java
+++ b/src/main/java/com/sparta/trelloproject/domain/card/repository/CardRepository.java
@@ -1,7 +1,15 @@
 package com.sparta.trelloproject.domain.card.repository;
 
+import static com.sparta.trelloproject.common.exception.ResponseCode.NOT_FOUND_CARD;
+
+import com.sparta.trelloproject.common.exception.NotFoundException;
 import com.sparta.trelloproject.domain.card.entity.Card;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CardRepository extends JpaRepository<Card, Long>, CardQueryRepository {
+
+    default Card findByCardId(Long cardId){
+        return findById(cardId)
+            .orElseThrow(() -> new NotFoundException(NOT_FOUND_CARD));
+    }
 }

--- a/src/main/java/com/sparta/trelloproject/domain/card/repository/CardRepository.java
+++ b/src/main/java/com/sparta/trelloproject/domain/card/repository/CardRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CardRepository extends JpaRepository<Card, Long>, CardQueryRepository {
 
-    default Card findByCardId(Long cardId){
+    default Card findByCardId(Long cardId) {
         return findById(cardId)
             .orElseThrow(() -> new NotFoundException(NOT_FOUND_CARD));
     }

--- a/src/main/java/com/sparta/trelloproject/domain/card/repository/ManagerRepository.java
+++ b/src/main/java/com/sparta/trelloproject/domain/card/repository/ManagerRepository.java
@@ -1,0 +1,9 @@
+package com.sparta.trelloproject.domain.card.repository;
+
+import com.sparta.trelloproject.domain.card.entity.Manager;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ManagerRepository extends JpaRepository<Manager, Long> {
+
+    boolean existsByUserIdAndCardId(Long id, Long id1);
+}

--- a/src/main/java/com/sparta/trelloproject/domain/card/service/CardService.java
+++ b/src/main/java/com/sparta/trelloproject/domain/card/service/CardService.java
@@ -1,4 +1,58 @@
 package com.sparta.trelloproject.domain.card.service;
 
+import com.sparta.trelloproject.common.exception.ForbiddenException;
+import com.sparta.trelloproject.common.exception.NotFoundException;
+import com.sparta.trelloproject.common.exception.ResponseCode;
+import com.sparta.trelloproject.common.s3.S3Service;
+import com.sparta.trelloproject.domain.card.dto.request.CardRequestDto;
+import com.sparta.trelloproject.domain.card.entity.Card;
+import com.sparta.trelloproject.domain.card.repository.CardImageRepository;
+import com.sparta.trelloproject.domain.card.repository.CardRepository;
+import com.sparta.trelloproject.domain.list.entity.Lists;
+import com.sparta.trelloproject.domain.list.repository.ListRepository;
+import com.sparta.trelloproject.domain.user.repository.UserRepository;
+import com.sparta.trelloproject.domain.workspace.entity.UserWorkspace;
+import com.sparta.trelloproject.domain.workspace.enums.WorkSpaceUserRole;
+import com.sparta.trelloproject.domain.workspace.repository.UserWorkSpaceRepository;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
 public class CardService {
+
+    private final CardRepository cardRepository;
+    private final ListRepository listRepository;
+    private final S3Service s3Service;
+    private final UserWorkSpaceRepository userWorkSpaceRepository;
+
+    public String saveCard(long userId, MultipartFile file, CardRequestDto cardRequestDto) {
+        try {
+            UserWorkspace userWorkspace = userWorkSpaceRepository.findByWorkspaceIdAndUserId(
+                cardRequestDto.getWorkSpaceId(), userId);
+
+            if (userWorkspace == null || WorkSpaceUserRole.ROLE_READ_USER.equals(
+                userWorkspace.getWorkSpaceUserRole())) {
+                throw new ForbiddenException(ResponseCode.INVALID_UPLOAD);
+            }
+
+            Lists lists = listRepository.findById(cardRequestDto.getListId())
+                .orElseThrow(() -> new NotFoundException(ResponseCode.NOT_FOUND_LIST));
+
+            Card card = Card.from(cardRequestDto, lists);
+            cardRepository.save(card);
+
+            String uploadImageUrl = s3Service.uploadFile(file, card);
+
+            return uploadImageUrl;
+        }
+        catch (IOException e) {
+            throw new ForbiddenException(ResponseCode.INVALID_UPLOAD);
+        }
+    }
 }
+

--- a/src/main/java/com/sparta/trelloproject/domain/card/service/CardService.java
+++ b/src/main/java/com/sparta/trelloproject/domain/card/service/CardService.java
@@ -1,10 +1,10 @@
 package com.sparta.trelloproject.domain.card.service;
 
-import com.sparta.trelloproject.common.annotation.AuthUser;
 import com.sparta.trelloproject.common.exception.ForbiddenException;
 import com.sparta.trelloproject.common.exception.NotFoundException;
 import com.sparta.trelloproject.common.exception.ResponseCode;
 import com.sparta.trelloproject.common.s3.S3Service;
+import com.sparta.trelloproject.domain.card.dto.reponse.CardListResponseDto;
 import com.sparta.trelloproject.domain.card.dto.request.CardRequestDto;
 import com.sparta.trelloproject.domain.card.entity.Card;
 import com.sparta.trelloproject.domain.card.entity.CardImage;
@@ -12,12 +12,15 @@ import com.sparta.trelloproject.domain.card.repository.CardImageRepository;
 import com.sparta.trelloproject.domain.card.repository.CardRepository;
 import com.sparta.trelloproject.domain.list.entity.Lists;
 import com.sparta.trelloproject.domain.list.repository.ListRepository;
-import com.sparta.trelloproject.domain.user.repository.UserRepository;
 import com.sparta.trelloproject.domain.workspace.entity.UserWorkspace;
 import com.sparta.trelloproject.domain.workspace.enums.WorkSpaceUserRole;
 import com.sparta.trelloproject.domain.workspace.repository.UserWorkSpaceRepository;
 import java.io.IOException;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -82,6 +85,15 @@ public class CardService {
         catch (IOException e) {
             throw new IllegalArgumentException("S3 파일 업로드에 실패하였습니다.");
         }
+    }
+
+    @Transactional(readOnly = true)
+    public Page<CardListResponseDto> getCardList(String title, String contents, String manager,
+        LocalDateTime dueDateFrom,
+        LocalDateTime dueDateTo, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        return cardRepository.findCardList(title, contents, manager, dueDateFrom, dueDateTo,
+            pageable);
     }
 }
 

--- a/src/main/java/com/sparta/trelloproject/domain/card/service/CardService.java
+++ b/src/main/java/com/sparta/trelloproject/domain/card/service/CardService.java
@@ -119,4 +119,11 @@ public class CardService {
         return response;
     }
 
+    //삭제관련 회의이후 수정!
+    public void deleteCard(Long id) {
+        Card card = cardRepository.findByCardId(id);
+
+        cardRepository.delete(card);
+    }
+
 }

--- a/src/main/java/com/sparta/trelloproject/domain/card/service/CardService.java
+++ b/src/main/java/com/sparta/trelloproject/domain/card/service/CardService.java
@@ -14,7 +14,6 @@ import com.sparta.trelloproject.domain.card.repository.CardImageRepository;
 import com.sparta.trelloproject.domain.card.repository.CardRepository;
 import com.sparta.trelloproject.domain.comment.dto.response.UpdateCommentResponse;
 import com.sparta.trelloproject.domain.comment.repository.CommentRepository;
-import com.sparta.trelloproject.domain.comment.service.CommentService;
 import com.sparta.trelloproject.domain.list.entity.Lists;
 import com.sparta.trelloproject.domain.list.repository.ListRepository;
 import com.sparta.trelloproject.domain.workspace.entity.UserWorkspace;

--- a/src/main/java/com/sparta/trelloproject/domain/card/service/CardService.java
+++ b/src/main/java/com/sparta/trelloproject/domain/card/service/CardService.java
@@ -80,8 +80,7 @@ public class CardService {
                 throw new ForbiddenException(ResponseCode.INVALID_UPLOAD);
             }
 
-            Card card = cardRepository.findById(cardId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 카드를 찾을 수 없습니다."));
+            Card card = cardRepository.findByCardId(cardId);
 
             CardImage cardImage = cardImageRepository.findByCardId(cardId);
             String filePath = cardImage.getPath();
@@ -91,7 +90,7 @@ public class CardService {
             return uploadImageUrl;
         }
         catch (IOException e) {
-            throw new IllegalArgumentException("S3 파일 업로드에 실패하였습니다.");
+            throw new ForbiddenException(ResponseCode.INVALID_UPLOAD);
         }
     }
 
@@ -106,8 +105,7 @@ public class CardService {
 
     @Transactional(readOnly = true)
     public CardResponseDto getCard(Long id) {
-        Card card = cardRepository.findById(id)
-            .orElseThrow(() -> new IllegalStateException("Could not find card"));
+        Card card = cardRepository.findByCardId(id);
 
         List<UpdateCommentResponse> comments = commentRepository.findByCardId(id).stream()
             .map(UpdateCommentResponse::from)
@@ -120,4 +118,5 @@ public class CardService {
         CardResponseDto response = CardResponseDto.of(card, comments, cardImageResponse);
         return response;
     }
+
 }

--- a/src/main/java/com/sparta/trelloproject/domain/card/service/ManagerService.java
+++ b/src/main/java/com/sparta/trelloproject/domain/card/service/ManagerService.java
@@ -1,0 +1,36 @@
+package com.sparta.trelloproject.domain.card.service;
+
+import com.sparta.trelloproject.common.exception.ForbiddenException;
+import com.sparta.trelloproject.common.exception.ResponseCode;
+import com.sparta.trelloproject.domain.card.dto.request.ManagerRequestDto;
+import com.sparta.trelloproject.domain.card.entity.Card;
+import com.sparta.trelloproject.domain.card.entity.Manager;
+import com.sparta.trelloproject.domain.card.repository.CardRepository;
+import com.sparta.trelloproject.domain.card.repository.ManagerRepository;
+import com.sparta.trelloproject.domain.user.entity.User;
+import com.sparta.trelloproject.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ManagerService {
+
+    private final UserRepository userRepository;
+    private final CardRepository cardRepository;
+    private final ManagerRepository managerRepository;
+
+    public void addManager(ManagerRequestDto requestDto) {
+        User user = userRepository.findByUserId(requestDto.getUserId());
+        Card card = cardRepository.findByCardId(requestDto.getCardId());
+
+        if (managerRepository.existsByUserIdAndCardId(user.getId(), card.getId())) {
+            throw new ForbiddenException(ResponseCode.MANAGER_ALREADY_EXISTS);
+        }
+
+        Manager manager = Manager.from(user, card);
+        managerRepository.save(manager);
+    }
+}

--- a/src/main/java/com/sparta/trelloproject/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/sparta/trelloproject/domain/comment/repository/CommentRepository.java
@@ -1,12 +1,14 @@
 package com.sparta.trelloproject.domain.comment.repository;
 
 import com.sparta.trelloproject.domain.comment.entity.Comment;
-import java.util.Collection;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CommentRepository extends JpaRepository<Comment, Long>, CommentQueryRepository {
 
-    List<Comment> findByCardId(Long id);
+    @Query("SELECT c FROM comments c JOIN FETCH c.user WHERE c.card.id = :cardId")
+    List<Comment> findByCardId(@Param("cardId") Long cardId);
 
 }

--- a/src/main/java/com/sparta/trelloproject/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/sparta/trelloproject/domain/comment/repository/CommentRepository.java
@@ -1,7 +1,12 @@
 package com.sparta.trelloproject.domain.comment.repository;
 
 import com.sparta.trelloproject.domain.comment.entity.Comment;
+import java.util.Collection;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentRepository extends JpaRepository<Comment, Long>, CommentQueryRepository {
+
+    List<Comment> findByCardId(Long id);
+
 }

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -13,6 +13,23 @@ spring:
         highlight_sql: true
         show_sql: true
         format_sql: true
+  servlet:
+    multipart:
+      max-file-size: 5MB
+      max-request-size: 5MB
+      enabled: true
+
+cloud:
+  aws:
+    s3:
+      bucket: ${S3_BUCKET}
+    credentials:
+      accessKey: ${S3_PUBLIC}
+      secretKey: ${S3_SECRET}
+    region:
+      static: ${S3_REGION}
+    stack:
+      auto: false
 
 logging:
   level:


### PR DESCRIPTION
카드 기능을 구현하였습니다
생성 - 카드 생성및 카드 이미지를 s3에 업로드 합니다
수정 - 카드 수정및 카드 이미지를 s3에서 교체합니다.
삭제 - 현재 미구현입니다
목록 조회 - querydsl을 사용하여 목록을 조회합니다.
단건 조회 - 단건조회를 하며 댓글과 이미지를 불러옵니다
매니저 등록 - 카드에 매니저를 등록합니다.
